### PR TITLE
Clean up interface to work with unsigned types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,13 @@ else()
   set(CRC_LIBRARY 1)
 endif()
 
+cmake_minimum_required(VERSION 3.1)
 project(crc)
 
 if(TARGET ${PROJECT_NAME})
   message("The ${PROJECT_NAME} arledy included in main Project")
   return()
 endif()
-
-cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_STANDARD 17)
@@ -30,7 +29,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
 
 if (CRC_TESTS)
-
     file(GLOB SOURCE_CPP_TEST
         "unit-test/*.h"
         "unit-test/*.cpp"
@@ -43,5 +41,7 @@ if (CRC_TESTS)
 
     add_executable(${PROJECT_NAME}_test ${SOURCE_CPP_TEST})
     target_link_libraries(${PROJECT_NAME}_test PUBLIC ${PROJECT_NAME})
-
+    enable_testing()
+    add_test(NAME crc
+        COMMAND ${PROJECT_NAME}_test)
 endif()

--- a/crc/crc16.c
+++ b/crc/crc16.c
@@ -51,7 +51,7 @@ static const uint16_t crc16tab[256]= {
     0x6e17,0x7e36,0x4e55,0x5e74,0x2e93,0x3eb2,0x0ed1,0x1ef0
 };
 
-uint16_t crc16(const char *buf, int len) {
+uint16_t crc16(const unsigned char *buf, size_t len) {
     int counter;
     uint16_t crc = 0;
     for (counter = 0; counter < len; counter++)

--- a/crc/crc16.h
+++ b/crc/crc16.h
@@ -1,12 +1,13 @@
 #ifndef _CRC_CRC16_H
 #define _CRC_CRC16_H
 
-#include <stdint.h>
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus  */
 
-uint16_t crc16(const char *buf, int len);
+#include <stdint.h>
+
+uint16_t crc16(const unsigned char *buf, size_t len);
 
 #ifdef __cplusplus
 }

--- a/crc/crc16.h
+++ b/crc/crc16.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif /* __cplusplus  */
 
+#include <stddef.h>
 #include <stdint.h>
 
 uint16_t crc16(const unsigned char *buf, size_t len);

--- a/crc/crc32.c
+++ b/crc/crc32.c
@@ -69,7 +69,7 @@ static uint32_t crc32_tab[] =
 };
 
 /* crc32 hash */
-uint32_t crc32(const char* s, int len)
+uint32_t crc32(const unsigned char *s, size_t len)
 {
     int i;
     uint32_t crc32val = 0;

--- a/crc/crc32.h
+++ b/crc/crc32.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif /* __cplusplus  */
 
+#include <stddef.h>
 #include <stdint.h>
 
 uint32_t crc32(const unsigned char *s, size_t len);

--- a/crc/crc32.h
+++ b/crc/crc32.h
@@ -1,12 +1,13 @@
 #ifndef _CRC_CRC32_H
 #define _CRC_CRC32_H
 
-#include <stdint.h>
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus  */
 
-uint32_t crc32(const char* s, int len);
+#include <stdint.h>
+
+uint32_t crc32(const unsigned char *s, size_t len);
 
 #ifdef __cplusplus
 }

--- a/crc/crc64.c
+++ b/crc/crc64.c
@@ -170,7 +170,7 @@ static const uint64_t crc64_tab[256] = {
     0x536fa08fdfd90e51ULL, 0x29b7d047efec8728ULL,
 };
 
-uint64_t crc64(const char *s, int l) {
+uint64_t crc64(const unsigned char *s, size_t l) {
     int j = 0;
     uint64_t crc = 0;
 

--- a/crc/crc64.h
+++ b/crc/crc64.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif /* __cplusplus  */
 
+#include <stddef.h>
 #include <stdint.h>
 
 uint64_t crc64(const unsigned char *s, size_t l);

--- a/crc/crc64.h
+++ b/crc/crc64.h
@@ -1,12 +1,13 @@
 #ifndef _CRC_CRC64_H
 #define _CRC_CRC64_H
 
-#include <stdint.h>
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus  */
 
-uint64_t crc64(const char *s, int l);
+#include <stdint.h>
+
+uint64_t crc64(const unsigned char *s, size_t l);
 
 #ifdef __cplusplus
 }

--- a/crc/crc8.c
+++ b/crc/crc8.c
@@ -87,7 +87,7 @@ static const uint8_t crc8tab_msb[256] = {
 };
 
 // LSB-first
-uint8_t crc8_lsb(const char *buf, int len) {
+uint8_t crc8_lsb(const unsigned char *buf, size_t len) {
     int counter;
     uint8_t crc = 0;
     for (counter = 0; counter < len; counter++)
@@ -96,7 +96,7 @@ uint8_t crc8_lsb(const char *buf, int len) {
 }
 
 // MSB-first
-uint8_t crc8_msb(const char *buf, int len) {
+uint8_t crc8_msb(const unsigned char *buf, size_t len) {
     int counter;
     uint8_t crc = 0;
     for (counter = 0; counter < len; counter++)

--- a/crc/crc8.h
+++ b/crc/crc8.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif /* __cplusplus  */
 
+#include <stddef.h>
 #include <stdint.h>
 
 // LSB-first

--- a/crc/crc8.h
+++ b/crc/crc8.h
@@ -1,17 +1,17 @@
 #ifndef _CRC_CRC8_H
 #define _CRC_CRC8_H
 
-#include <stdint.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus  */
 
+#include <stdint.h>
+
 // LSB-first
-uint8_t crc8_lsb(const char *buf, int len);
+uint8_t crc8_lsb(const unsigned char *buf, size_t len);
 
 // MSB-first
-uint8_t crc8_msb(const char *buf, int len);
+uint8_t crc8_msb(const unsigned char *buf, size_t len);
 
 #ifdef __cplusplus
 }

--- a/crc/crc_poly.h
+++ b/crc/crc_poly.h
@@ -1,11 +1,11 @@
 #ifndef _CRC_CRC_POLY_H
 #define _CRC_CRC_POLY_H
 
-#include <stdint.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus  */
+
+#include <stdint.h>
 
 // LSB-first
 uint8_t crc8_poly_lsb(uint8_t poly, uint8_t value);

--- a/crc/crchash.cpp
+++ b/crc/crchash.cpp
@@ -12,27 +12,27 @@
 namespace common {
     uint16_t Hash16(const std::string& key)
     {
-        return crc16(key.c_str(), key.size());
+        return crc16(reinterpret_cast<const unsigned char *>(key.c_str()), key.size());
     }
-    uint16_t Hash16(const char* cpKey, const int iKeyLen)
+    uint16_t Hash16(const unsigned char *cpKey, const size_t iKeyLen)
     {
         return crc16(cpKey, iKeyLen);
     }
 
     uint32_t Hash32(const std::string& key)
     {
-        return crc32(key.c_str(), key.size());
+        return crc32(reinterpret_cast<const unsigned char *>(key.c_str()), key.size());
     }
-    uint32_t Hash32(const char* cpKey, const int iKeyLen)
+    uint32_t Hash32(const unsigned char *cpKey, const size_t iKeyLen)
     {
         return crc32(cpKey, iKeyLen);
     }
 
     uint64_t Hash64(const std::string& key)
     {
-        return crc64(key.c_str(), key.size());
+        return crc64(reinterpret_cast<const unsigned char *>(key.c_str()), key.size());
     }
-    uint64_t Hash64(const char* cpKey, const int iKeyLen)
+    uint64_t Hash64(const unsigned char *cpKey, size_t iKeyLen)
     {
         return crc64(cpKey, iKeyLen);
     }

--- a/crc/crchash.h
+++ b/crc/crchash.h
@@ -8,18 +8,19 @@
 #ifndef _COMMON_CRC_CRCHASH_H_
 #define _COMMON_CRC_CRCHASH_H_
 #include <string>
-#include <stdint.h>
+#include <cstdint>
+
 namespace common {
     // string => 0x0000-0xffff
     uint16_t Hash16(const std::string& key);
-    uint16_t Hash16(const char* cpKey, const int iKeyLen);
+    uint16_t Hash16(const unsigned char *cpKey, size_t iKeyLen);
 
     // string => 0x00000000-0xffffffff
     uint32_t Hash32(const std::string& key);
-    uint32_t Hash32(const char* cpKey, const int iKeyLen);
+    uint32_t Hash32(const unsigned char *cpKey, size_t iKeyLen);
 
     // string => 0x0000000000000000-0xffffffffffffffff
     uint64_t Hash64(const std::string& key);
-    uint64_t Hash64(const char* cpKey, const int iKeyLen);    
+    uint64_t Hash64(const unsigned char *cpKey, size_t iKeyLen);
 } // namespace common
 #endif  // _COMMON_CRC_CRCHASH_H_

--- a/unit-test/crc_test.cpp
+++ b/unit-test/crc_test.cpp
@@ -18,14 +18,19 @@ TEST(CRC8Test, BasicTest)
 {
     const char* inData = "123456789";
     uint8_t expect = 0xa2;
-    EXPECT_EQ(crc8_msb(inData, 9), expect);
+    EXPECT_EQ(crc8_msb(reinterpret_cast<const unsigned char *>(inData), 9), expect);
 
     const char* data = "Hello World!!!";
     expect = 0x68;
-    EXPECT_EQ(crc8_msb(data, strlen(data)), expect);
+    EXPECT_EQ(crc8_msb(reinterpret_cast<const unsigned char *>(data), strlen(data)), expect);
 
     expect = 0x2c;
-    EXPECT_EQ(crc8_lsb(data, strlen(data)), expect);
+    EXPECT_EQ(crc8_lsb(reinterpret_cast<const unsigned char *>(data), strlen(data)), expect);
+
+    const uint8_t buffer[] = {0xb0, 0, 0, 0, 0, 0, 0};
+
+    expect = 0x1a;
+    EXPECT_EQ(crc8_lsb(buffer, sizeof(buffer)), expect);
 }
 
 TEST(CRC16Test, BasicTest)
@@ -33,7 +38,7 @@ TEST(CRC16Test, BasicTest)
     const char* inData = "123456789";
     uint16_t expect = 0x31C3;
 
-    EXPECT_EQ(crc16(inData, 9), expect);
+    EXPECT_EQ(crc16(reinterpret_cast<const unsigned char *>(inData), 9), expect);
 }
 
 TEST(CRC32Test, BasicTest)
@@ -41,7 +46,7 @@ TEST(CRC32Test, BasicTest)
     const char* inData = "123456789";
     uint32_t expect = 0xCBF43926;
 
-    EXPECT_EQ(crc32(inData, 9), expect);
+    EXPECT_EQ(crc32(reinterpret_cast<const unsigned char *>(inData), 9), expect);
 }
 
 TEST(CRC64Test, BasicTest)
@@ -49,7 +54,7 @@ TEST(CRC64Test, BasicTest)
     const char* inData = "123456789";
 
     uint64_t expect = 0xe9c6d914c4b8d9caL;
-    EXPECT_EQ(crc64(inData, 9), expect);
+    EXPECT_EQ(crc64(reinterpret_cast<const unsigned char *>(inData), 9), expect);
 }
 
 TEST(CRC8PolyTest, BasicTest)

--- a/unit-test/crc_test.cpp
+++ b/unit-test/crc_test.cpp
@@ -6,13 +6,12 @@
 */
 
 #include "ut/test_harness.h"
-#include "../crc/crc8.h"
-#include "../crc/crc16.h"
-#include "../crc/crc32.h"
-#include "../crc/crc64.h"
-#include "../crc/crc_poly.h"
-#include <iostream>
-#include <string.h>
+#include "crc/crc8.h"
+#include "crc/crc16.h"
+#include "crc/crc32.h"
+#include "crc/crc64.h"
+#include "crc/crc_poly.h"
+#include <cstring>
 
 TEST(CRC8Test, BasicTest)
 {

--- a/unit-test/ut/test_harness.cpp
+++ b/unit-test/ut/test_harness.cpp
@@ -1,12 +1,9 @@
 #include "test_harness.h"
 
-#include <string>
-#include <string.h>
-#include <stdlib.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/time.h>
 #include <vector>
+#include <string>
+#include <cstring>
+#include <ctime>
 
 namespace common {
     namespace test {
@@ -80,9 +77,15 @@ namespace common {
                 startMs_, endMs, endMs - startMs_);
         }
         long TestPerfomence::NowMs() {
-            struct timeval timeNow;
-            gettimeofday(&timeNow, NULL);
-            return (timeNow.tv_sec) * 1000 + timeNow.tv_usec / 1000;
+            timespec timeNow{};
+
+            if (timespec_get(&timeNow, TIME_UTC) != TIME_UTC)
+            {
+                fputs("timespec_get failed!", stderr);
+                return 0;
+            }
+
+            return static_cast<long>(timeNow.tv_sec * 1000 + timeNow.tv_nsec / 1000);
         }
 
     }

--- a/unit-test/ut/test_harness.h
+++ b/unit-test/ut/test_harness.h
@@ -48,7 +48,7 @@ class Tester {
         fname_, line_, ss_.str().c_str());
       fprintf(stderr, "\033[0m");
       errCount++;
-      //exit(1);
+      exit(1);
     }
   }
 
@@ -64,7 +64,7 @@ class Tester {
   template <class X, class Y>                           \
   Tester& name(const X& x, const Y& y) {                \
     if (! (x op y)) {                                   \
-      ss_ << " failed: Expect:" << x << (" " #op " ") << "Actual:" << y;    \
+      ss_ << " failed: Expect:" << std::hex << uint64_t {x} << (" " #op " ") << "Actual:" << std::hex << uint64_t {y};    \
       ok_ = false;                                                   \
     }                                                   \
     return *this;                                       \


### PR DESCRIPTION
These changes address the issue described in the #5 due to usage of signed data for CRC calculation.

Fix: #5